### PR TITLE
更新actions/upload-artifact到v4版本

### DIFF
--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -60,7 +60,7 @@ jobs:
           pynsist installer.cfg
           
       - name: Upload Windows artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: FCS-Sampler-Tool-Windows-v${{ steps.get_version.outputs.VERSION }}
           path: |


### PR DESCRIPTION
修复Windows构建工作流中的actions/upload-artifact版本，从v3更新到v4。